### PR TITLE
Update mmfusion.py with max video length assertion

### DIFF
--- a/examples/MMPT/demo_sign.py
+++ b/examples/MMPT/demo_sign.py
@@ -1,5 +1,3 @@
-import sys
-
 import torch
 import numpy as np
 from pose_format import Pose
@@ -7,14 +5,17 @@ from pose_format import Pose
 from mmpt.models import MMPTModel
 
 import mediapipe as mp
+import argparse
+from pathlib import Path
+
 mp_holistic = mp.solutions.holistic
-FACEMESH_CONTOURS_POINTS = [str(p) for p in sorted(set([p for p_tup in list(mp_holistic.FACEMESH_CONTOURS) for p in p_tup]))]
-MAX_FRAMES = 256 # see also max_video_length in MMPT/mmpt/models/mmfusion.py" # TODO: check the model.max_video_len instead?
+FACEMESH_CONTOURS_POINTS = [str(p) for p in sorted(set(p for p_tup in mp_holistic.FACEMESH_CONTOURS for p in p_tup))]
+MAX_FRAMES_DEFAULT = 256  # Default truncate length, can be overridden
 
-
+# Model configurations
 model_configs = [
-    ('default', 'signclip_v1_1/baseline_temporal'),
-    ('asl_citizen', 'signclip_asl/asl_citizen_finetune'),
+    ("default", "signclip_v1_1/baseline_temporal"),
+    ("asl_citizen", "signclip_asl/asl_citizen_finetune"),
 ]
 models = {}
 
@@ -29,23 +30,23 @@ for model_name, config_path in model_configs:
         model.cuda()
 
     models[model_name] = {
-        'model': model,
-        'tokenizer': tokenizer,
-        'aligner': aligner,
+        "model": model,
+        "tokenizer": tokenizer,
+        "aligner": aligner,
     }
 
 
 def pose_normalization_info(pose_header):
     if pose_header.components[0].name == "POSE_LANDMARKS":
-        return pose_header.normalization_info(p1=("POSE_LANDMARKS", "RIGHT_SHOULDER"),
-                                            p2=("POSE_LANDMARKS", "LEFT_SHOULDER"))
-
+        return pose_header.normalization_info(
+            p1=("POSE_LANDMARKS", "RIGHT_SHOULDER"), p2=("POSE_LANDMARKS", "LEFT_SHOULDER")
+        )
     if pose_header.components[0].name == "BODY_135":
         return pose_header.normalization_info(p1=("BODY_135", "RShoulder"), p2=("BODY_135", "LShoulder"))
-
     if pose_header.components[0].name == "pose_keypoints_2d":
-        return pose_header.normalization_info(p1=("pose_keypoints_2d", "RShoulder"),
-                                                p2=("pose_keypoints_2d", "LShoulder"))
+        return pose_header.normalization_info(
+            p1=("pose_keypoints_2d", "RShoulder"), p2=("pose_keypoints_2d", "LShoulder")
+        )
 
 
 def pose_hide_legs(pose):
@@ -64,34 +65,29 @@ def pose_hide_legs(pose):
         raise ValueError("Unknown pose header schema for hiding legs")
 
 
-def preprocess_pose(pose):
-    pose = pose.get_components(["POSE_LANDMARKS", "FACE_LANDMARKS", "LEFT_HAND_LANDMARKS", "RIGHT_HAND_LANDMARKS"], 
-                        {"FACE_LANDMARKS": FACEMESH_CONTOURS_POINTS})
+def preprocess_pose(pose, max_frames=None):
+    pose = pose.get_components(
+        ["POSE_LANDMARKS", "FACE_LANDMARKS", "LEFT_HAND_LANDMARKS", "RIGHT_HAND_LANDMARKS"],
+        {"FACE_LANDMARKS": FACEMESH_CONTOURS_POINTS},
+    )
 
     pose = pose.normalize(pose_normalization_info(pose.header))
     pose = pose_hide_legs(pose)
-    
-    # from sign_vq.data.normalize import pre_process_mediapipe, normalize_mean_std
-    # from pose_anonymization.appearance import remove_appearance
-
-    # pose = remove_appearance(pose)
-    # pose = pre_process_mediapipe(pose)
-    # pose = normalize_mean_std(pose)
 
     feat = np.nan_to_num(pose.body.data)
     feat = feat.reshape(feat.shape[0], -1)
 
-    pose_frames = torch.from_numpy(np.expand_dims(feat, axis=0)).float() # .size() is torch.Size([1, frame count, 609])
-    if pose_frames.size(1) > MAX_FRAMES:
-        print(f"Video too long for signCLIP. Truncating to {MAX_FRAMES} from {pose_frames.size(1)}")
-        pose_frames = pose_frames[:, :MAX_FRAMES, :]
-        
+    pose_frames = torch.from_numpy(np.expand_dims(feat, axis=0)).float()  # .size() is torch.Size([1, frame count, 609])
+    if max_frames is not None and pose_frames.size(1) > max_frames:
+        print(f"Video too long for signCLIP. Truncating to {max_frames} from {pose_frames.size(1)}")
+        pose_frames = pose_frames[:, :max_frames, :]
+
     return pose_frames
 
 
-def preprocess_text(text, model_name='default'):
-    aligner = models[model_name]['aligner']
-    tokenizer = models[model_name]['tokenizer']
+def preprocess_text(text, model_name="default"):
+    aligner = models[model_name]["aligner"]
+    tokenizer = models[model_name]["tokenizer"]
 
     caps, cmasks = aligner._build_text_seq(
         tokenizer(text, add_special_tokens=False)["input_ids"],
@@ -101,73 +97,52 @@ def preprocess_text(text, model_name='default'):
     return caps, cmasks
 
 
-def embed_pose(pose, model_name='default'):
-    model = models[model_name]['model']
+def score_pose_and_text(pose, text, max_frames, model_name="default"):
+    model = models[model_name]["model"]
 
-    caps, cmasks = preprocess_text('', model_name)
-    poses = pose if type(pose) == list else [pose]
-    embeddings = []
-
-    for pose in poses:
-        pose_frames = preprocess_pose(pose)
-
-        with torch.no_grad():
-            output = model(pose_frames, caps, cmasks, return_score=False)
-            embeddings.append(output['pooled_video'].cpu().numpy())
-
-    return np.concatenate(embeddings)
-
-
-def embed_text(text, model_name='default'):
-    model = models[model_name]['model']
-
-    # pose_frames = torch.randn(1, 1, 534)
-    pose_frames = torch.randn(1, 1, 609)
-    texts = text if type(text) == list else [text]
-    embeddings = []
-
-    for text in texts:
-        caps, cmasks = preprocess_text(text, model_name)
-
-        with torch.no_grad():
-            output = model(pose_frames, caps, cmasks, return_score=False)
-            embeddings.append(output['pooled_text'].cpu().numpy())
-
-    return np.concatenate(embeddings)
-
-
-def score_pose_and_text(pose, text, model_name='default'):
-    model = models[model_name]['model']
-
-    pose_frames = preprocess_pose(pose)
+    pose_frames = preprocess_pose(pose, max_frames)
     caps, cmasks = preprocess_text(text)
 
     with torch.no_grad():
         output = model(pose_frames, caps, cmasks, return_score=True)
-    
+
     return text, float(output["score"])  # dot-product
 
 
-def score_pose_and_text_batch(pose, text, model_name='default'):
-    pose_embedding = embed_pose(pose, model_name)
-    text_embedding = embed_text(text, model_name)
+def main():
+    parser = argparse.ArgumentParser(description="Evaluate pose and text similarity using SignCLIP.")
+    parser.add_argument("pose_path", 
+                        default='/shares/volk.cl.uzh/zifjia/RWTH_Fingerspelling/pose/1_1_1_cam2.pose'
+                        type=Path, help="Path to the .pose file.")
+    parser.add_argument(
+        "--max_frames",
+        type=int,
+        default=MAX_FRAMES_DEFAULT,
+        help=f"Maximum number of frames to process. Pose sequences longer than this will be truncated. Default is {MAX_FRAMES_DEFAULT}, as SignCLIP can currently only support this many.",
+    )
 
-    scores = np.matmul(pose_embedding, text_embedding.T)
-    return scores
+    args = parser.parse_args()
 
+    pose_path = args.pose_path
+    max_frames = args.max_frames
 
-if __name__ == "__main__":
-    pose_path = '/shares/volk.cl.uzh/zifjia/RWTH_Fingerspelling/pose/1_1_1_cam2.pose' if len(sys.argv) < 2 else sys.argv[1]
+    if not pose_path.is_file():
+        print(f"Error: File {pose_path} does not exist.")
+        return
 
     with open(pose_path, "rb") as f:
         buffer = f.read()
         pose = Pose.read(buffer)
 
-        print(score_pose_and_text(pose, 'random text'))
-        print(score_pose_and_text(pose, 'house'))
-        print(score_pose_and_text(pose, '<en> <ase> house'))
-        print(score_pose_and_text(pose, '<en> <gsg> house'))
-        print(score_pose_and_text(pose, '<en> <fsl> house'))
-        print(score_pose_and_text(pose, '<en> <ase> sun'))
-        print(score_pose_and_text(pose, '<en> <ase> police'))
-        print(score_pose_and_text(pose, '<en> <ase> how are you?'))
+        print(score_pose_and_text(pose, "random text", max_frames))
+        print(score_pose_and_text(pose, "house", max_frames))
+        print(score_pose_and_text(pose, "<en> <ase> house", max_frames))
+        print(score_pose_and_text(pose, "<en> <gsg> house", max_frames))
+        print(score_pose_and_text(pose, "<en> <fsl> house", max_frames))
+        print(score_pose_and_text(pose, "<en> <ase> sun", max_frames))
+        print(score_pose_and_text(pose, "<en> <ase> police", max_frames))
+        print(score_pose_and_text(pose, "<en> <ase> how are you?", max_frames))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/MMPT/mmpt/models/mmfusion.py
+++ b/examples/MMPT/mmpt/models/mmfusion.py
@@ -66,8 +66,9 @@ class MMPTModel(nn.Module):
 
     def forward(self, video_frames, caps, cmasks, return_score=False):
         bsz = video_frames.size(0)
-        assert bsz == 1, "only bsz=1 is supported now."
+        assert bsz == 1, "only bsz=1 is supported now, received video_frames.size()={video_frames.size()}"
         seq_len = video_frames.size(1)
+        assert seq_len <= self.max_video_len, f"Video too long. Received frame count {video_frames.size(1)} greater than configured max_video_len ({self.max_video_len})"
         if self.video_encoder:
             video_frames = video_frames.view(-1, *video_frames.size()[2:])
             vfeats = self.video_encoder(video_frames.permute(0, 4, 1, 2, 3))


### PR DESCRIPTION
This PR just adds an assertion to check if the number of frames passed is too long. Otherwise you get a very arcane error like this one I got when trying to embed a pose sequence from sem-lex:

```
python demo_sign_embed_and_save.py ~/data/debugging_negative_dimension_error/
2024-11-25 09:29:41 | ERROR | root | Trying to create tensor with negative dimension -14: [1, -14, 609]
Traceback (most recent call last):
  File "demo_sign_embed_and_save.py", line 268, in <module>
    embeddings = embed_pose(pose, model_name)
  File "demo_sign_embed_and_save.py", line 145, in embed_pose
    output = model(pose_frames, caps, cmasks, return_score=False)
  File "/home/vlab/miniconda3/envs/signclip/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1553, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
  File "/home/vlab/miniconda3/envs/signclip/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1562, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/vlab/projects/semantic-sign-language-search/setup_signCLIP/fairseq/examples/MMPT/mmpt/models/mmfusion.py", line 78, in forward
    padding = torch.zeros(
RuntimeError: Trying to create tensor with negative dimension -14: [1, -14, 609]
error when processing /home/vlab/data/debugging_negative_dimension_error/ErCKX5SzkKOkslF24yua.pose.zst: Trying to create tensor with negative dimension -14: [1, -14, 609] using model asl-citizen  
```

This also solves the mystery of why I was getting _so many errors_ when embedding sem-lex .pose files I had created myself. As described in https://github.com/sign-language-processing/pose/issues/127, nearly half of them were failing with negative dimension error. Well, those would be the ones with the vp9 codec. The fps on those got set to 1000, so the number of frames easily exceeded 256.


I got this problem because I was using [ this script ](https://github.com/cleong110/semantic-sign-language-search/blob/main/setup_signCLIP/demo_sign_embed_and_save.py) to embed files, derived from the demo script. I took the liberty of adding a truncation step to preprocess_pose in that script.